### PR TITLE
Add feature to jump to a specific page

### DIFF
--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -87,12 +87,12 @@ export default {
       this.$store.dispatch('toggleMdivModal')
     },
     jumpToPage: function () {
-      const page = parseInt(this.pageInput) === NaN ? 0 : parseInt(this.pageInput) - 1;
-      if (page >= 0 && page <= this.$store.getters.maxPageNumber) {
+      const page = this.inputPage === NaN ? 0 : parseInt(this.inputPage) - 1
+      if (page >= 0 && page < this.$store.getters.maxPageNumber) {
         this.$store.dispatch('setCurrentPage', page)
       }
       else {
-        console.info('Invalid page number');
+        console.info('Invalid page number: ', this.inputPage)
       }
     }
     /* showImageSelectionOverlay: function () {

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -16,6 +16,10 @@
           <span @click="showNextPage" :disabled="!nextAvailable">
             <font-awesome-icon icon="fa-solid fa-angle-right" />
           </span>
+          <span class="ml-2">
+            <input type="text" class="input pageInput" v-model="pageInput" :placeholder="currentPage" />
+            <button class="btn jumpBtn" @click="jumpToPage()">Go</button>
+          </span>
         </div>
         <div class="column col-3">
           zones: {{ zonesCount }}
@@ -35,6 +39,11 @@ export default {
   name: 'AppFooter',
   components: {
 
+  },
+  data() {
+    return {
+      pageInput: ''
+    }
   },
   computed: {
     currentPage: function () {
@@ -76,6 +85,15 @@ export default {
     },
     showMdivModal: function () {
       this.$store.dispatch('toggleMdivModal')
+    },
+    jumpToPage: function () {
+      const page = parseInt(this.pageInput) === NaN ? 0 : parseInt(this.pageInput) - 1;
+      if (page >= 0 && page <= this.$store.getters.maxPageNumber) {
+        this.$store.dispatch('setCurrentPage', page)
+      }
+      else {
+        console.info('Invalid page number');
+      }
     }
     /* showImageSelectionOverlay: function () {
       this.$store.dispatch('showImageSelectionModal')
@@ -107,5 +125,25 @@ export default {
     border: $thinBorder;
     background: #eef0f3 linear-gradient(to right, #999999 30%, #eef0f3 30%) top left/150% 150% no-repeat;
   }
+
+  button {
+    color: $fontColorDark;
+    border-color: $fontColorDark;
+  }
+  
+  .pageInput {
+    width: 2rem;
+    height: 1rem;
+    text-align: center;
+    border: $thinBorder;
+    border-radius: .2rem;
+    padding: .1rem;
+  }
+
+  .jumpBtn {
+      padding: 0 .1rem;
+      height: 1rem;
+      margin: 0 .2rem;
+    }
 }
 </style>

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -12,14 +12,11 @@
           <span @click="showPrevPage" :disabled="!prevAvailable">
             <font-awesome-icon icon="fa-solid fa-angle-left" />
           </span>
-          {{ currentPage }} / {{ maxPage }}
+          <input type="text" class="ml-2 input pageInput" v-model="inputPage" v-on:keyup.enter="jumpToPage()" :placeholder="currentPage"/> / {{ maxPage }}
           <span @click="showNextPage" :disabled="!nextAvailable">
             <font-awesome-icon icon="fa-solid fa-angle-right" />
           </span>
-          <span class="ml-2">
-            <input type="text" class="input pageInput" v-model="pageInput" :placeholder="currentPage" />
-            <button class="btn jumpBtn" @click="jumpToPage()">Go</button>
-          </span>
+          <button class="ml-2 btn jumpBtn" @click="jumpToPage()">Go</button>
         </div>
         <div class="column col-3">
           zones: {{ zonesCount }}
@@ -40,9 +37,9 @@ export default {
   components: {
 
   },
-  data() {
+  data: function () {
     return {
-      pageInput: ''
+      inputPage: ''
     }
   },
   computed: {
@@ -75,12 +72,19 @@ export default {
       return (mdiv.index + 1) + ': ' + mdiv.label
     }
   },
+  watch: {
+    currentPage: function (newPage) {
+      this.inputPage = newPage
+    }
+  },
   methods: {
     showPrevPage: function () {
+      this.currentPage = this.currentPage - 1
       this.$store.dispatch('setCurrentPage', this.$store.getters.currentPageIndexZeroBased - 1)
       this.$store.dispatch('setCurrentPageZone', this.$store.getters.zonesOnCurrentPage.length)
     },
     showNextPage: function () {
+      this.currentPage = this.currentPage + 1
       this.$store.dispatch('setCurrentPage', this.$store.getters.currentPageIndexZeroBased + 1)
     },
     showMdivModal: function () {


### PR DESCRIPTION
This pull request introduces a new feature that allows users to jump to a specific page number. The feature has been implemented in the footer section.

Changes:
- Added a page input field in the footer to allow direct page navigation.
- Implemented functionality to validate and process user input.

Issue Reference:
This PR addresses issue #22.

Testing:
- Manually tested the feature with the default IIIF import.
- Verified edge cases such as invalid inputs and out-of-range numbers.