### PR TITLE
Removing the @xmlns from copied surface element

### DIFF
--- a/src/tools/iiif.js
+++ b/src/tools/iiif.js
@@ -36,6 +36,7 @@ function addPage (canvas,canvases,  dimension, n, file, meiSurfaceTemplate, hasI
   surface.setAttribute('label', label)
   surface.setAttribute('lrx', width)
   surface.setAttribute('lry', height)
+  surface.removeAttribute('xmlns')
 
   const graphic = surface.querySelector('graphic')
   graphic.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:id', graphicId)


### PR DESCRIPTION
This commit removes the `@xmlns` from the `<surface/>` when it is cloned to fix #25.  