### PR TITLE
Set colors for mdivs dynamically and repeat after 10 mdivs

### DIFF
--- a/src/components/OsdComponent.vue
+++ b/src/components/OsdComponent.vue
@@ -15,6 +15,15 @@ export default {
   components: {
 
   },
+  data() {
+    return {
+      colors: [
+        'rgba(255, 87, 51, 0.2)', 'rgba(51, 255, 87, 0.2)', 'rgba(51, 87, 255, 0.2)', 'rgba(255, 51, 161, 0.2)', 'rgba(161, 51, 255, 0.2)',
+        'rgba(51, 255, 245, 0.2)', 'rgba(255, 140, 51, 0.2)', 'rgba(140, 255, 51, 0.2)', 'rgba(51, 140, 255, 0.2)', 'rgba(255, 51, 140, 0.2)'
+      ],
+      colorIndex: 0
+    }
+  },
   computed: {
     imageArray: function () {
       return this.$store.getters.imageArray
@@ -27,7 +36,11 @@ export default {
     }
   },
   methods: {
-  
+    getNextColor() {
+      const color = this.colors[this.colorIndex];
+      this.colorIndex = (this.colorIndex + 1) % this.colors.length;
+      return color;
+    },
     renderZones: function () {
       this.viewer.clearOverlays()
       const annots = this.$store.getters.zonesOnCurrentPage
@@ -98,7 +111,24 @@ export default {
           e.stopPropagation()
         })
 
+        // Set the background color dynamically
+        const color = this.getNextColor();
+        const borderColor = color.replace(/[\d\.]+\)$/g, '0.5)')
+        
+        // Set colors
+        overlay.style.backgroundColor = color
+        overlay.style.outline = `1px solid ${borderColor}`
 
+        // Set colors for :hover
+        overlay.onmouseenter = () => {
+          overlay.style.backgroundColor = color.replace(/[\d\.]+\)$/g, '0.1)')
+          overlay.style.outline = borderColor.replace(/[\d\.]+\)$/g, '0.4)')
+        }
+        // Reset colors after :hover
+        overlay.onmouseleave = () => {
+          overlay.style.backgroundColor = color
+          overlay.style.outline = borderColor
+        }
 
         this.viewer.addOverlay({
           element: overlay,
@@ -297,126 +327,6 @@ $thickLineColor: #cccccc66; // #ffffff99;
   .zone {
     background-color: rgba(255,255,255,.1);
     z-index: 10;
-
-    &.mov_0 {
-      background-color: transparentize($mdiv0ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv0ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv0ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv0ZoneColor, .4);
-      }
-    }
-
-    &.mov_1 {
-      background-color: transparentize($mdiv1ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv1ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv1ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv1ZoneColor, .4);
-      }
-    }
-
-    &.mov_2 {
-      background-color: transparentize($mdiv2ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv2ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv2ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv2ZoneColor, .4);
-      }
-    }
-
-    &.mov_3 {
-      background-color: transparentize($mdiv3ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv3ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv3ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv3ZoneColor, .4);
-      }
-    }
-
-    &.mov_4 {
-      background-color: transparentize($mdiv4ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv4ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv4ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv4ZoneColor, .4);
-      }
-    }
-
-    &.mov_5 {
-      background-color: transparentize($mdiv5ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv5ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv5ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv5ZoneColor, .4);
-      }
-    }
-
-    &.mov_6 {
-      background-color: transparentize($mdiv6ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv6ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv6ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv6ZoneColor, .4);
-      }
-    }
-
-    &.mov_7 {
-      background-color: transparentize($mdiv7ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv7ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv7ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv7ZoneColor, .4);
-      }
-    }
-
-    &.mov_8 {
-      background-color: transparentize($mdiv8ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv8ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv8ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv8ZoneColor, .4);
-      }
-    }
-
-    &.mov_9 {
-      background-color: transparentize($mdiv9ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv9ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv9ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv9ZoneColor, .4);
-      }
-    }
-
-    &.mov_10 {
-      background-color: transparentize($mdiv10ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv10ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv10ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv10ZoneColor, .4);
-      }
-    }
-
-    &.mov_11 {
-      background-color: transparentize($mdiv11ZoneColor, .8);
-      outline: 1px solid transparentize($mdiv11ZoneColor, .4);
-
-      &:hover {
-        background-color: transparentize($mdiv11ZoneColor, .6);
-        outline: 1px solid transparentize($mdiv11ZoneColor, .4);
-      }
-    }
 
     .zoneLabel {
       text-align: center;

--- a/src/components/OsdComponent.vue
+++ b/src/components/OsdComponent.vue
@@ -21,7 +21,8 @@ export default {
         'rgba(255, 87, 51, 0.2)', 'rgba(51, 255, 87, 0.2)', 'rgba(51, 87, 255, 0.2)', 'rgba(255, 51, 161, 0.2)', 'rgba(161, 51, 255, 0.2)',
         'rgba(51, 255, 245, 0.2)', 'rgba(255, 140, 51, 0.2)', 'rgba(140, 255, 51, 0.2)', 'rgba(51, 140, 255, 0.2)', 'rgba(255, 51, 140, 0.2)'
       ],
-      colorIndex: 0
+      colorIndex: 0,
+      mdivColors: {}
     }
   },
   computed: {
@@ -59,6 +60,15 @@ export default {
         const measureCssLink = annot.body.find(body => body.type === 'Dataset' && body.selector.value.startsWith('measure'))?.selector.value
         const mdivCssLink = annot.body.find(body => body.type === 'Dataset' && body.selector.value.startsWith('mdiv'))?.selector.value
         const mdivIndizes = annot.body.find(body => body.type === 'Dataset' && body.selector.value.startsWith('mov_'))?.selector.value
+
+        console.log('mdivIndizes', mdivIndizes)
+
+        // Get or assign color for mdiv
+        if (!this.mdivColors[mdivIndizes]) {
+          this.mdivColors[mdivIndizes] = this.getNextColor()
+        }
+        const color = this.mdivColors[mdivIndizes]
+        const borderColor = color.replace(/[\d\.]+\)$/g, '0.5)')
         
         console.log("this is xywh " , "", xywh.x,"", xywh.y, "", xywh.w, "", xywh.h)
 
@@ -110,10 +120,6 @@ export default {
           e.preventDefault()
           e.stopPropagation()
         })
-
-        // Set the background color dynamically
-        const color = this.getNextColor();
-        const borderColor = color.replace(/[\d\.]+\)$/g, '0.5)')
         
         // Set colors
         overlay.style.backgroundColor = color
@@ -121,13 +127,13 @@ export default {
 
         // Set colors for :hover
         overlay.onmouseenter = () => {
-          overlay.style.backgroundColor = color.replace(/[\d\.]+\)$/g, '0.1)')
-          overlay.style.outline = borderColor.replace(/[\d\.]+\)$/g, '0.4)')
+          overlay.style.backgroundColor = color.replace(/[\d\.]+\)$/g, '0.1)');
+          overlay.style.outline = borderColor.replace(/[\d\.]+\)$/g, '0.4)');
         }
         // Reset colors after :hover
         overlay.onmouseleave = () => {
-          overlay.style.backgroundColor = color
-          overlay.style.outline = borderColor
+          overlay.style.backgroundColor = color;
+          overlay.style.outline = borderColor;
         }
 
         this.viewer.addOverlay({


### PR DESCRIPTION
This PR addresses #29 and sets the colours for `<mdiv/>` dynamically and repeats them after ten `<mdiv/>`. 

The following can be used to test the changes when uploaded as MEI to the Cartographer.
```xml
<mei xmlns="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:svg="http://www.w3.org/2000/svg" meiversion="5.0.0-dev" xml:id="m52636013-0ba9-4395-8761-a88d3e3c1787">
    <meiHead>
        <fileDesc>
            <titleStmt>
                <title>A-Wn SH.Beethoven.323</title>
            </titleStmt>
            <pubStmt/>
            <sourceDesc>
                <source xml:id="s4c417c69-45cb-4593-bc47-7b7d44d4071c" target="https://api.beethovens-werkstatt.de/iiif/document/r24d1c005-acee-43a0-acfa-5dae796b7ec4/manifest.json" xlink:role="http://iiif.io/api/presentation/2#Manifest"/>
            </sourceDesc>
        </fileDesc>
        <encodingDesc>
            <appInfo>
                <application xml:id="mercatorApp">
                    <name>Mercator-App</name>
                    <ptr target="https://github.com/Edirom/mercator-app"/>
                </application>
            </appInfo>
        </encodingDesc>
        <revisionDesc>
            <change n="1">
                <respStmt>
                    <persName authURI="https://github.com/Hizkie">Hizkiel Alemayehu</persName>
                    <persName authURI="https://github.com/kepper">Johannes Kepper</persName>
                </respStmt>
                <changeDesc>
                    <p>
                        File initially generated from IIIF Manifest available at <ptr target="#s4c417c69-45cb-4593-bc47-7b7d44d4071c"/>,
                        using <ptr target="#mercatorApp"/>. This is a generic converter,
                        so the resulting file may require considerable adjustments to
                        match local practice.
                    </p>
                </changeDesc>
                <date isodate="2025-02-24"/>
            </change>
        </revisionDesc>
    </meiHead>
    <music meiversion="5.0.0-dev">
        <facsimile>
            <surface xmlns="http://www.music-encoding.org/ns/mei" xml:id="sc1982fd3-bbbd-4f32-9999-9f5ca6f01757" n="5" ulx="0" uly="0" lrx="4291" lry="5532" label="3">
    <graphic xml:id="ge7a223f3-9f25-47e1-a4c0-d2a7f950debf" target="https://edirom-images.beethovens-werkstatt.de/Scaler/IIIF/A-Wn_SH.Beethoven.323%2F005.jpg/info.json" type="facsimile" width="4291" height="5532"/>
<zone xml:id="zdfc90a89-2610-4d05-9da2-dc5b3356dea7" type="measure" ulx="1111" uly="528" lrx="1715" lry="1180"/><zone xml:id="z292f64c6-9ae0-4c75-8931-161bc639aaca" type="measure" ulx="1655" uly="595" lrx="2307" lry="1150"/><zone xml:id="za888eb9f-0ad6-48ba-8ca2-25915fd7106d" type="measure" ulx="2226" uly="621" lrx="2867" lry="1187"/><zone xml:id="z563e3331-ef78-41e9-bf48-fc615a1708bf" type="measure" ulx="2759" uly="610" lrx="3273" lry="1240"/><zone xml:id="z5767e20f-a1d4-4c0c-907b-1f83bc228f54" type="measure" ulx="3161" uly="651" lrx="3858" lry="1162"/><zone xml:id="z101cf8e0-dd6e-41f9-8845-fa4ca3a5fdf4" type="measure" ulx="414" uly="1165" lrx="936" lry="1780"/><zone xml:id="z0fd05072-d1db-4143-bff8-a59b2bb57b46" type="measure" ulx="795" uly="1243" lrx="1324" lry="1802"/><zone xml:id="z0e3d04df-22a7-42fe-8d5b-80026c1d46d5" type="measure" ulx="1231" uly="1191" lrx="1771" lry="1795"/><zone xml:id="zd3bd3972-6984-4cef-b3b7-626a0ec7e317" type="measure" ulx="1652" uly="1091" lrx="2319" lry="1803"/><zone xml:id="zaee7cdd4-5195-4c4d-aed9-9b345d0213a9" type="measure" ulx="2270" uly="1191" lrx="2825" lry="1795"/><zone xml:id="zaef0b21c-5d1a-4b17-ac39-55b86c182cf2" type="measure" ulx="2762" uly="1262" lrx="3332" lry="1925"/><zone xml:id="z2c39ba74-8376-48a1-810e-90a9d9aa39b8" type="measure" ulx="3243" uly="1236" lrx="3806" lry="1873"/></surface></facsimile>
        <body>
            
        <mdiv xml:id="m507fe1d8-80b2-4685-bb99-92d0b4eb7db3" label="Movement 1"><score><section/></score></mdiv><mdiv xml:id="m6c000942-e095-427a-8aeb-d1c55c7c7bdb" label="Movement 2"><score><section><pb facs="#sc1982fd3-bbbd-4f32-9999-9f5ca6f01757" n="5"/><measure xml:id="b8454815c-cf25-44d6-be8a-e9123732c900" facs="#zdfc90a89-2610-4d05-9da2-dc5b3356dea7" n="1"/></section></score></mdiv><mdiv xml:id="me75b65dc-5a74-464a-90d4-8d506af885a3" label="Movement 3"><score><section><measure xml:id="b98972fef-cabc-4ab1-99e6-72e8721dc0a8" facs="#z292f64c6-9ae0-4c75-8931-161bc639aaca" n="1"/></section></score></mdiv><mdiv xml:id="m1a6ae2dc-21cb-4241-a546-f221af140cf3" label="Movement 4"><score><section><measure xml:id="bbc1b6a3e-3feb-4e8d-997a-cb576f42765f" facs="#za888eb9f-0ad6-48ba-8ca2-25915fd7106d" n="1"/></section></score></mdiv><mdiv xml:id="m244477c3-0dac-4230-b83a-493cd66559be" label="Movement 5"><score><section><measure xml:id="bf3b3fc67-705f-4323-bc6a-81b65173488d" facs="#z563e3331-ef78-41e9-bf48-fc615a1708bf" n="1"/></section></score></mdiv><mdiv xml:id="m628a5416-5adb-4a40-8753-d64c6fba13d2" label="Movement 6"><score><section><measure xml:id="b8728b266-399f-46d0-b0c4-f1a25912c52c" facs="#z5767e20f-a1d4-4c0c-907b-1f83bc228f54" n="1"/></section></score></mdiv><mdiv xml:id="mb9a9861f-ed78-4573-8d1b-8646649a8154" label="Movement 7"><score><section><sb/><measure xml:id="b9db10db8-92eb-4091-b3f6-1950d10be9ed" facs="#z101cf8e0-dd6e-41f9-8845-fa4ca3a5fdf4" n="1"/></section></score></mdiv><mdiv xml:id="mbcfce1f4-befb-48b9-858b-eadda9468773" label="Movement 8"><score><section><measure xml:id="ba98a8dc3-666e-435a-881b-b1396d12ecae" facs="#z0fd05072-d1db-4143-bff8-a59b2bb57b46" n="1"/></section></score></mdiv><mdiv xml:id="m2384b7cc-8525-4261-8db2-2a0555fb0851" label="Movement 9"><score><section><measure xml:id="b36cf8562-e30d-41d5-849d-af38c0d0ca69" facs="#z0e3d04df-22a7-42fe-8d5b-80026c1d46d5" n="1"/></section></score></mdiv><mdiv xml:id="md0430595-39aa-4f5d-ba42-22b2f46235d4" label="Movement 10"><score><section><measure xml:id="b9b574345-9e5d-4686-b4a4-1f8f4dbe03da" facs="#zd3bd3972-6984-4cef-b3b7-626a0ec7e317" n="1"/></section></score></mdiv><mdiv xml:id="m8234dd5d-56fa-421a-9b7f-e6f4c6125c13" label="Movement 11"><score><section><measure xml:id="b2121342e-d565-441a-9644-138282bb1e05" facs="#zaee7cdd4-5195-4c4d-aed9-9b345d0213a9" n="1"/></section></score></mdiv><mdiv xml:id="me22b6b7f-61d9-46e0-be60-6836df4f8e27" label="Movement 12"><score><section><measure xml:id="bd115ee9b-220a-4aa1-b6a4-89cdce143536" facs="#zaef0b21c-5d1a-4b17-ac39-55b86c182cf2" n="1"/></section></score></mdiv><mdiv xml:id="meb1cdd3d-a7fc-4d35-9b41-624ed9b348f9" label="Movement 13"><score><section><measure xml:id="b28e4affe-0453-4776-899a-1e3e0198cded" facs="#z2c39ba74-8376-48a1-810e-90a9d9aa39b8" n="1"/><pb facs="#sc1982fd3-bbbd-4f32-9999-9f5ca6f01757" n="5"/><pb facs="#sc1982fd3-bbbd-4f32-9999-9f5ca6f01757" n="5"/></section></score></mdiv></body>
    </music>
</mei>
```