### PR TITLE
Trailing "info.json" removed

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -812,7 +812,7 @@ export default createStore({
             for (let i = 0; i < canvases.length; i++) {
               try {
                 // Build the info.json URL for the current canvas
-                const infoUrl = canvases[i].images[0].resource.service['@id'] + "/info.json";
+                const infoUrl = canvases[i].images[0].resource.service['@id'];
                 
                 // Push the URL to the state.infoJson array
                 state.infoJson.push(infoUrl);
@@ -880,7 +880,7 @@ export default createStore({
     
           // Map all canvas images to their info.json URLs
           const infoJsonUrls = canvases.map(canvas => {
-            return canvas.images[0].resource.service['@id'] + "/info.json";
+            return canvas.images[0].resource.service['@id'];
           });
     
           // Store all fetch promises for info.json

--- a/src/tools/iiif.js
+++ b/src/tools/iiif.js
@@ -17,10 +17,10 @@ function addPage (canvas,canvases,  dimension, n, file, meiSurfaceTemplate, hasI
   var uri = ""
   if(hasItems == true){
     console.log("has item is true")
-    uri = canvas?.items[0]?.items[0]?.body?.service[0].id+"/info.json"
+    uri = canvas?.items[0]?.items[0]?.body?.service[0].id
   }else{
     console.log("has item is false")
-     uri = canvas?.images[0]?.resource?.service['@id']+"/info.json"
+     uri = canvas?.images[0]?.resource?.service['@id']
   }
 
 


### PR DESCRIPTION
I could not find any side effects after deleting the `info.json` from the URL's. I tested with the following steps and everything worked:

1. Download Test-IIIF
2. Draw zones
3. Download MEI
4. Upload MEI again

and

1. Upload MEI created with the previous version (with `info.json` in urls)
2. Download it again

The zones are displayed correctly even if the uploaded file has the urls have the `info.json` in it and it is not removed from the existing zones.