### PR TITLE
Disable add-zone-to-last-measure button when no measure exists

### DIFF
--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -34,9 +34,11 @@
     </button> -->
 
     <!-- ADDITIONAL ZONE PER MEASURE -->
+      <!-- @click="activateMode('additionalZone')"> -->
     <button class="btn btn-action"  :class="{'activeMode': mode === 'additionalZone'}"
-      title="add zone to last measure" :disabled="!isReady"
-      @click="activateMode('additionalZone')">
+      title="add zone to last measure"
+      :disabled="!isReady || measures.length === 0"
+      @click="printCurrentMeasure">
       <template v-if="mode === 'additionalZone'">
         <font-awesome-icon icon="fa-solid fa-square-plus"/>
       </template>
@@ -158,6 +160,9 @@ export default {
     },
     mode: function () {
       return this.$store.getters.mode
+    },
+    measures: function () {
+      return this.$store.getters.measures
     }
     /* visible: function() {
       return this.$store.getters.imageSelectionModalVisible


### PR DESCRIPTION
The 'Add zone to last measure' button will be disabled until at least one measure is added.
This is achieved by calling the measures getter in the sidebar component. However, we should discuss whether creating a new 'doesMeasureExist' getter in index.js, which returns a simple Boolean value, would be a better solution than loading all measures.