### PR TITLE
Bug/45 create standardized issue templates for the repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,10 +14,6 @@ A clear and concise description of what the bug is.
 **To Reproduce**
 
 Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
 
 **Expected behavior**
 
@@ -28,7 +24,6 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
-- OS:
 - Browser:
 - Version:
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Problem Report
+about: Report a bug or unexpected behavior
+title: "[Bug] "
+labels: bug
+assignees: ""
+
+---
+
+**Describe the bug**
+
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+
+If applicable, add screenshots to help explain your problem.
+
+**Environment (please complete the following information):**
+- OS:
+- Browser:
+- Version:
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: "[Feature] "
+labels: enhancement
+assignees: ""
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+
+A clear and concise description of the problem you're facing.
+
+**Describe the solution you'd like**
+
+What would you like to see happen?
+
+**Describe alternatives you've considered**
+
+Any alternative solutions or approaches you've tried or thought of.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/release_new_version.md
+++ b/.github/ISSUE_TEMPLATE/release_new_version.md
@@ -1,0 +1,23 @@
+---
+name: Release New Version
+about: Propose or track the release of a new version
+title: "[Release] "
+labels: release
+assignees: ""
+
+---
+
+**Version to be released**
+
+Provide the version number (e.g., v1.0.0).
+
+**Reason for release**
+
+Explain what changes, fixes, or features are included.
+
+**Checklist**
+- [ ] Code is stable and reviewed
+- [ ] Documentation is updated
+- [ ] All tests pass
+- [ ] Changelog is updated
+- [ ] Tag and release notes are ready


### PR DESCRIPTION
##  Pull Request: Add Standardized Issue Templates

### Summary

This PR introduces a set of standardized GitHub issue templates to improve the quality and consistency of issue reporting across the project.

### What's Included

- `feature_request.md` – For suggesting new features or enhancements.
- `bug_report.md` – For reporting bugs or unexpected behavior.
- `release_new_version.md` – For initiating or tracking a new release.
- `blank_issue.md` – For open-ended issues without a predefined structure.
- `config.yml` – For configuring templates.


### Notes

- Templates are located in `.github/ISSUE_TEMPLATE/`

