### PR TITLE
resolving issue #53

### DIFF
--- a/src/tools/meiMappings.js
+++ b/src/tools/meiMappings.js
@@ -35,8 +35,6 @@ export function meiZone2annotorious (mei, zoneInput, pageUri) {
 
   if (measures.length === 0) {
     console.error('\nHouston!!!')
-    console.log(zoneInput)
-    console.log(zoneId)
   }
 
   const mdivIds = []
@@ -223,7 +221,6 @@ export function insertMeasure (xmlDoc, measure, state, currentZone, pageIndex, t
   let relativeWhere
 
   const pbAlreadyStarted = pb !== undefined
-  // console.log('pb started: ' + pbAlreadyStarted)
 
   if (pbAlreadyStarted) {
     // insert relative to that page
@@ -250,8 +247,6 @@ export function insertMeasure (xmlDoc, measure, state, currentZone, pageIndex, t
       relativeWhere = 'before'
     }
   }
-
-  console.log('need to insert ' + relativeWhere, relativeTo)
 
   const surface = xmlDoc.querySelectorAll('surface')[pageIndex]
   const zones = [...surface.querySelectorAll('zone')]
@@ -314,7 +309,7 @@ export function insertMeasure (xmlDoc, measure, state, currentZone, pageIndex, t
   const insertIntoRightSystem = (xmlDoc, surface, targetMdiv, newZone, newMeasure, zones, pageHeight, thresholdDistance, zonesToIncrement, lastGroup) => {
     const currentTop = zones[0].top
     const currentThreshold = currentTop + thresholdDistance
-    // console.log('looking for measures above ' + currentThreshold)
+    // Looking for measures above ' + currentThreshold
 
     const above = []
     const below = []
@@ -416,7 +411,6 @@ export function insertMeasure (xmlDoc, measure, state, currentZone, pageIndex, t
             const precedingMeasure = targetMdiv.querySelector('measure[facs~="#' + precedingZoneId + '"]')
             newMeasure.setAttribute('n', incrementMeasureNum(precedingMeasure.getAttribute('n'), 1))
             precedingMeasure.after(newMeasure)
-  
             // create sb, insert after preceding measure
             const sb = document.createElementNS('http://www.music-encoding.org/ns/mei', 'sb')
             precedingMeasure.after(sb)
@@ -438,10 +432,14 @@ export function insertMeasure (xmlDoc, measure, state, currentZone, pageIndex, t
             }else{
               newMeasure.setAttribute('n', incrementMeasureNum(precedingMeasure.getAttribute('n'), 1))
               precedingMeasure.after(newMeasure)
-    
               // create sb, insert after preceding measure
               const sb = document.createElementNS('http://www.music-encoding.org/ns/mei', 'sb')
               precedingMeasure.after(sb)
+
+              if (newMeasure.nextSibling && newMeasure.nextSibling.tagName === 'sb') {
+                newMeasure.nextSibling.remove()
+              }
+
             }
 
   
@@ -547,9 +545,7 @@ export function getFollowingMeasuresByMeasure (measure) {
 export function addZoneToLastMeasure (xmlDoc, zoneId) {
   const measure = getLastMeasure(xmlDoc)
   const oldFacs = measure.hasAttribute('facs') ? measure.getAttribute('facs') + ' ' : ''
-  console.log("last measure ", measure)
   measure.setAttribute('facs', oldFacs + '#' + zoneId)
-  console.log("new measure ", measure)
 }
 
 /**
@@ -594,7 +590,6 @@ function getPrecedingZoneNoMatterWhere (xmlDoc, zone) {
   let precedingSibling = zone.previousElementSibling
 
   while (precedingSibling !== null && precedingZone === null) {
-    console.log('looking at ', precedingSibling)
     if (precedingSibling.localName === 'zone') {
       precedingZone = precedingSibling
     } else {
@@ -690,7 +685,6 @@ export function createNewMdiv (xmlDoc, afterMdivId) {
  */
 export function deleteZone (xmlDoc, id, state) {
   const currentPage = state.currentPage
-  console.log('this is deleted zone id  ' + id)
   const surface = xmlDoc.querySelectorAll('surface')[currentPage]
   const zone = [...surface.querySelectorAll('zone')].find(zone => zone.getAttribute('xml:id') === id)
 
@@ -714,7 +708,6 @@ export function deleteZone (xmlDoc, id, state) {
       })
 
       if (measure.nextElementSibling !== null) {
-        console.log('measure is ', measure, ' section is ', measure.closest('section'))
         if (measure.previousElementSibling.tagName === 'pb' && measure.nextElementSibling.tagName === 'sb') {
           measure.nextElementSibling.remove()
         } else if (measure.previousElementSibling.tagName === 'sb' && measure.nextElementSibling.tagName === 'sb') {
@@ -757,11 +750,9 @@ export function toggleAdditionalZone (xmlDoc, id, state) {
 
     if (!state.existingMusicMode) {
       if (facsArr.indexOf('#' + precedingZoneId) !== -1) {
-        // console.log('This zone is part of preceding measure and should get a new measure instead')
         const index = facsArr.indexOf('#' + id)
         facsArr.splice(index, 1)
         measure.setAttribute('facs', facsArr.join(' '))
-        // console.log('setting @facs to ' + facsArr.join(' '))
         const followingMeasures = getFollowingMeasuresByMeasure(measure)
         const newMeasure = generateMeasure()
         newMeasure.setAttribute('facs', '#' + id)
@@ -771,7 +762,6 @@ export function toggleAdditionalZone (xmlDoc, id, state) {
           measure.setAttribute('n', incrementMeasureNum(measure.getAttribute('n'), 1))
         })
       } else {
-        // console.log('I need to add this zone to the measure of the preceding zone')
         const precedingMeasures = getMeasuresFromZone(xmlDoc, precedingZone)
         precedingMeasures.forEach(precedingMeasure => {
           precedingMeasure.setAttribute('facs', precedingMeasure.getAttribute('facs') + ' #' + id)
@@ -787,7 +777,7 @@ export function toggleAdditionalZone (xmlDoc, id, state) {
     // shifting zones in measures with existing content
     } else {
       if (facsArr.indexOf('#' + precedingZoneId) !== -1) {
-        // console.log('This zone is part of preceding measure and should get a new measure instead')
+        // This zone is part of preceding measure and should get a new measure instead'
         const index = facsArr.indexOf('#' + id)
         facsArr.splice(index, 1)
         measure.setAttribute('facs', facsArr.join(' '))
@@ -807,7 +797,7 @@ export function toggleAdditionalZone (xmlDoc, id, state) {
         })
       } else {
         // conflate -> move zones closer to begin of mdiv
-        // console.log('I need to add this zone to the measure of the preceding zone')
+        // I need to add this zone to the measure of the preceding zone'
         const precedingMeasures = getMeasuresFromZone(xmlDoc, precedingZone)
         precedingMeasures.forEach(precedingMeasure => {
           precedingMeasure.setAttribute('facs', precedingMeasure.getAttribute('facs') + ' #' + id)
@@ -846,7 +836,6 @@ export function setMultiRest (measure, val) {
     oldVal = parseInt(existingMultiRests[0].getAttribute('num'))
     // a new value for multiRest shall be written
     if (val !== null) {
-      console.log('case 1')
       existingMultiRests.forEach(mr => {
         mr.setAttribute('num', val)
       })
@@ -854,16 +843,15 @@ export function setMultiRest (measure, val) {
       const layerContent = measure.querySelectorAll('layer *')
       const otherContent = [...layerContent].find(elem => elem.localName !== 'multiRest')
       if (otherContent !== undefined) { // remove multiRests only
-        console.log('case 2a')
         existingMultiRests.forEach(mr => mr.remove())
       } else { // remove whole tree
-        console.log('case 2b')
         measure.querySelectorAll('staff').forEach(staff => staff.remove())
       }
     }
-  } else { // no prior multiRests available
-    if (val !== null) { // insert new multiRest to measure
-      console.log('case 3')
+  } else { 
+    // no prior multiRests available
+    if (val !== null) { 
+      // insert new multiRest to measure
       const staff = document.createElementNS('http://www.music-encoding.org/ns/mei', 'staff')
       staff.setAttribute('n', 1)
       const layer = document.createElementNS('http://www.music-encoding.org/ns/mei', 'layer')
@@ -875,14 +863,11 @@ export function setMultiRest (measure, val) {
       layer.append(multiRest)
       measure.append(staff)
     } else {
-      console.log('case 4')
       // no existing multiRest, and no multiRest is wanted -> do nothing
     }
   }
 
   const diff = ((val !== null) ? val : 1) - oldVal
-  console.log("old value ", oldVal, " diff: ", diff, " val: ", val)
-
   const followingMeasures = getFollowingMeasuresByMeasure(measure)
   if (diff !== 0) {
     followingMeasures.forEach(measure => {
@@ -904,8 +889,6 @@ export function setMultiRest (measure, val) {
  * @param {Object} state - Application state (used for page lookup).
  */
 export function moveContentToMdiv (xmlDoc, firstMeasureId, targetMdivId, state) {
-  console.log('trying to move measure ' + firstMeasureId + ' to mdiv ' + targetMdivId)
-
   const firstMeasure = [...xmlDoc.querySelectorAll('measure')].find(measure => measure.getAttribute('xml:id') === firstMeasureId)
   const precedingSibling = firstMeasure.previousElementSibling
   let firstNode


### PR DESCRIPTION
Resolve issue #53 by removing the existing <sb> before adding the new one. 
Testing steps 

> Open IIIF example and autogenerate measure for the page 5.
> Delete the first measure of the second system.
> Redraw the first measure of the second system.
> Download ME

Expected Behaviour

The application should maintain only one <sb/> at the beginning of a system when redrawing the first measure, without inserting a duplicate tag.

The output
```xml
<measure xml:id="bce1bc6ee-d2de-46a0-82cb-c5c30616d3ec" facs="#d8fa14a27-dd19-4b3b-b8e1-a7785ebc7f65" n="31"/>
<sb/>
<measure xml:id="b5bc87a5a-703b-4bcf-9329-c7493fcc12cf" facs="#z6036451e-cedd-4a48-9f43-2f3068585551" n="32"/>
<measure xml:id="b4257b34b-ab4c-4f96-bdc4-ba131c04d2f2" facs="#dd092ad95-a82e-4805-9f7a-c7fae9fff14f" n="33"/>
```