### PR TITLE
Resolving issue 37

### DIFF
--- a/src/components/LoadIIIFModal.vue
+++ b/src/components/LoadIIIFModal.vue
@@ -63,6 +63,7 @@ export default {
       if (input.validity.valid) {
         this.$store.dispatch('importIIIF', input.value)
         this.closeModal()
+        this.$store.dispatch('resetAll')
       }
     },
     closeModal: function () {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -6,11 +6,10 @@ import { mode as allowedModes } from '@/store/constants.js'
 
 const parser = new DOMParser()
 const serializer = new XMLSerializer()
-export default createStore({
-  modules: {
-  },
-    state: {
-      selectedRepo: null,            // Currently selected GitHub repository
+
+function getDefaultState() {
+  return {
+ selectedRepo: null,            // Currently selected GitHub repository
       selectedDirectory: null,       // Currently selected directory within the repo
       directories: [],               // List of directories in the selected repo
       repos: null,                   // List of available repositories
@@ -42,11 +41,18 @@ export default createStore({
       importingImages: [],           // Array of images being imported (with status)
       currentMeasureId: null,        // xml:id of the currently selected measure
       infoJson: []                   // Array of IIIF info.json URLs for canvases
+  }
+}
+
+export default createStore({
+  modules: {
   },
+    state: getDefaultState(),
   /**
  * Vuex mutations for managing application state.
  * Each mutation updates a specific part of the state in response to actions or UI events.
  *
+ * - RESET_STATE: Resets the entire application state to its default values.
  * - TOGGLE_LOADXML_MODAL: Toggle the visibility of the XML file load modal.
  * - TOGGLE_LOADIIIF_MODAL: Toggle the visibility of the IIIF manifest load modal.
  * - TOGGLE_LOADGIT_MODAL: Toggle the visibility of the GitHub load modal.
@@ -86,6 +92,9 @@ export default createStore({
  * - CANCEL_IMAGE_IMPORTS: Cancel all pending image imports and hide the import modal.
  */
   mutations: {
+    RESET_STATE(state) {
+        Object.assign(state, getDefaultState())
+      },
     TOGGLE_LOADXML_MODAL(state) {
       state.showLoadXMLModal = !state.showLoadXMLModal
     },
@@ -355,6 +364,7 @@ export default createStore({
  * Actions can dispatch mutations, perform async tasks, and coordinate multiple state changes.
  *
  * - fetchDirectories: Fetches directory listings from a GitHub repository (example, not fully implemented).
+ * - resetAll: Resets the entire application state to its default values.
  * - toggleLoadXMLModal: Toggles the visibility of the XML file load modal.
  * - toggleLoadIIIFModal: Toggles the visibility of the IIIF manifest load modal.
  * - toggleMeasureModal: Toggles the visibility of the measure label/number modal.
@@ -404,6 +414,9 @@ export default createStore({
         console.error(error);
       }
     },
+    resetAll({ commit }) {
+      commit('RESET_STATE')
+    },
     toggleLoadXMLModal({ commit }) {
       commit('TOGGLE_LOADXML_MODAL')
     },
@@ -434,78 +447,7 @@ export default createStore({
     },
     importIIIF({ commit, dispatch, state }, url) {
       commit('SET_LOADING', true);
-    
-      // Fetch the IIIF manifest
-      fetch(url)
-        .then(res => res.json())
-        .then(json => {
-          commit('SET_LOADING', false);
-          commit('SET_PROCESSING', true);
-    
-          let canvases = json.sequences[0].canvases;
-    
-          // Process each canvas one by one, sequentially
-          const processCanvasesSequentially = async () => {
-            for (let i = 0; i < canvases.length; i++) {
-              try {
-                // Build the info.json URL for the current canvas
-                const infoUrl = canvases[i].images[0].resource.service['@id'];
-                
-                // Push the URL to the state.infoJson array
-                state.infoJson.push(infoUrl);
-                
-                // Fetch the info.json
-                const res = await fetch(infoUrl);
-                const result = await res.json();
-    
-                // Check if this is a proper IIIF Manifest, then convert to MEI
-                const isManifest = checkIiifManifest(json);
-                if (!isManifest) {
-                  throw new Error("Invalid IIIF manifest");
-                }
-    
-                // Extract the width and height from the result
-                const width = result.width;
-                const height = result.height;
-    
-                // Push the dimensions into the state.pageDimension array
-                state.pageDimension.push([width, height]);
-    
-              } catch (error) {
-                console.error(`Error processing canvas ${i}:`, error);
-                throw error; // This will stop the loop and be caught in the outer catch block
-              }
-            }
-          };
-    
-          // Call the sequential processing function
-          processCanvasesSequentially()
-            .then(() => {
-              // After processing all canvases, convert the manifest to MEI
-              return iiifManifest2mei(json, url, parser, state);
-            })
-            .then(mei => {
-              // Dispatch setData with the generated MEI
-              dispatch('setData', mei);
-            })
-            .catch(err => {
-              console.error('Error processing IIIF manifest or canvases:', err);
-              commit('SET_LOADING', false);
-              // Add any additional error messaging here
-            })
-            .finally(() => {
-              commit('SET_PROCESSING', false); // Ensure processing is set to false after completion
-            });
-        })
-        .catch(error => {
-          // Handle errors in the initial IIIF manifest fetch
-          console.error('Error fetching IIIF manifest:', error);
-          commit('SET_LOADING', false);
-        });
-    },
-    importIIIF({ commit, dispatch, state }, url) {
-      commit('SET_LOADING', true);
-    
+
       // Fetch the IIIF manifest
       fetch(url)
         .then(res => res.json())


### PR DESCRIPTION

- Resolving issue #37 by resetting the state to default values when importing new images. 
- Cleaning up the index code by removing duplicated insertIIIF function 
-  Added the necessary comments. 

Tested using two IIIF images 

1. Load the manifest of the first source.
2. Export MEI.
3. Load the manifest of a second source in the same tab.
4. Export MEI.


No values from the previous MEI.  



