### PR TITLE
Update screen size

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <script type="text/javascript">window.PUBLIC_PATH;</script>
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0,viewport-fit=cover">
     <link rel="icon">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>

--- a/src/components/AppFooter.vue
+++ b/src/components/AppFooter.vue
@@ -116,8 +116,9 @@ export default {
 .appFooter {
   position: absolute;
   bottom: 0;
-  height: $appFooterHeight;
-  width: 100vw;
+  height: calc(#{$appFooterHeight} + env(safe-area-inset-bottom, 0px));
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  width: 100%;
   background-color: $appColor;
   border-top: $thickBorder;
   box-sizing: border-box;
@@ -153,5 +154,57 @@ export default {
       height: 1rem;
       margin: 0 .2rem;
     }
+}
+
+// Small screens (phones): keep the footer on a single row and make its
+// contents fit instead of overflowing / being clipped.
+@media (max-width: 599px) {
+  .appFooter {
+    font-size: .6rem;
+
+    .container,
+    .columns {
+      flex-wrap: nowrap;
+      align-items: center;
+      height: 100%;
+    }
+
+    .column {
+      padding-left: 2px;
+      padding-right: 2px;
+      min-width: 0;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    // The mdiv label is supplementary (also reachable via the mdiv modal),
+    // so let it shrink/truncate first to give the page navigation room.
+    .col-4.text-left {
+      flex: 0 1 auto;
+      width: auto;
+    }
+
+    // Page navigation and zone count keep their natural width (most useful);
+    // the progress column absorbs any remaining space.
+    .col-4:not(.text-left),
+    .col-3 {
+      flex: 0 0 auto;
+      width: auto;
+    }
+
+    .col-1 {
+      flex: 1 1 auto;
+      width: auto;
+    }
+
+    .pageInput {
+      width: 1.4rem;
+    }
+
+    .jumpBtn {
+      margin: 0 .1rem;
+    }
+  }
 }
 </style>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -37,7 +37,8 @@ export default {
 @import '@/css/_variables.scss';
 
 .appHeader {
-  height: $appHeaderHeight;
+  height: calc(#{$appHeaderHeight} + env(safe-area-inset-top, 0px));
+  padding-top: env(safe-area-inset-top, 0px);
   background-color: $appColor;
   border-bottom: $thickBorder;
   box-sizing: border-box;
@@ -53,6 +54,18 @@ export default {
       color: $fontColorDark;
       border-color: $fontColorDark;
       margin-left: .3rem;
+    }
+  }
+}
+
+// Small screens (phones): shrink the brand so it fits the header height and
+// leaves room for the menu button.
+@media (max-width: 599px) {
+  .appHeader {
+    .navbar-brand {
+      padding-left: .5rem;
+      font-size: .95rem;
+      white-space: nowrap;
     }
   }
 }

--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -233,6 +233,7 @@ export default {
 
 .appSidebar {
   height: calc(100vh - $appHeaderHeight - $appFooterHeight);
+  height: calc(100dvh - #{$appHeaderHeight} - #{$appFooterHeight} - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
   width: $appSidebarWidth;
   background-color: $appColor;
   float: right;

--- a/src/components/ContentPreviewPane.vue
+++ b/src/components/ContentPreviewPane.vue
@@ -34,6 +34,7 @@ export default {
 
 .contentPreviewPane {
   height: calc(100vh - $appHeaderHeight - $appFooterHeight);
+  height: calc(100dvh - #{$appHeaderHeight} - #{$appFooterHeight} - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
   width: $contentPreviewPaneWidth;
   background-color: #ffffff;
   padding: .2rem;

--- a/src/components/OsdComponent.vue
+++ b/src/components/OsdComponent.vue
@@ -154,9 +154,37 @@ export default {
       })
       // this.anno.setAnnotations(annots)
     },
-    toggleSelection: function (mode) {
+    isDrawingMode: function (mode) {
       const activeModes = [allowedModes.manualRect, allowedModes.additionalZone]
-      this.anno.readOnly = activeModes.indexOf(mode) === -1
+      const currentMode = mode !== undefined ? mode : this.mode
+      return activeModes.indexOf(currentMode) !== -1
+    },
+    toggleSelection: function (mode) {
+      const drawing = this.isDrawingMode(mode)
+      this.anno.readOnly = !drawing
+
+      // On touch / small-screen devices there is no Shift key to raise the
+      // drawing layer, so enable it automatically whenever a drawing mode
+      // (manualRect / additionalZone) is active.
+      const annoLayer = document.querySelector('.a9s-annotationlayer.a9s-osd-annotationlayer')
+      if (annoLayer) {
+        annoLayer.classList.toggle('activeSelection', drawing)
+      }
+
+      // Disable OpenSeadragon's own gesture navigation while drawing so that
+      // touch drags reach the annotation layer instead of panning/zooming the
+      // image. Re-enabled for non-drawing tools (e.g. selection) to allow
+      // pan/pinch-zoom on touch devices.
+      if (this.viewer) {
+        this.viewer.setMouseNavEnabled(!drawing)
+      }
+
+      // Annotorious only enables its drawing MouseTracker while the Shift
+      // hotkey is held. Touch devices have no Shift key, so enable/disable the
+      // tracker explicitly based on the active tool instead.
+      if (this.anno) {
+        this.anno.setDrawingEnabled(drawing)
+      }
     }
   },
   mounted: function () {
@@ -189,7 +217,8 @@ export default {
 
     // Initialize the Annotorious plugin
     this.anno = Annotorious(this.viewer, annotoriousConfig)
-    this.anno.setDrawingEnabled(true)
+    // Set the initial drawing state to match the current tool/mode.
+    this.toggleSelection(this.mode)
 
 
     // Load annotations in W3C WebAnnotation format
@@ -204,7 +233,9 @@ export default {
       }
     } 
     const shiftKeyUp = (e) => {
-      if (e.keyCode === 16) {
+      // Keep the drawing layer active when a drawing mode is selected, so
+      // releasing Shift on desktop does not disable an active draw tool.
+      if (e.keyCode === 16 && !this.isDrawingMode()) {
         annoLayer.classList.remove('activeSelection')
       }
     }
@@ -244,6 +275,12 @@ export default {
       this.$store.dispatch('selectZone', null)
       this.anno.clearAnnotations()
       this.renderZones()
+      // Annotorious disables its drawing tracker after each completed shape
+      // (it normally waits for the Shift hotkey again). Re-enable it so the
+      // user can keep drawing on touch devices without a keyboard.
+      if (this.isDrawingMode()) {
+        this.anno.setDrawingEnabled(true)
+      }
       console.log("anno is clicked ", annotation.target.selector)
     })
 
@@ -313,6 +350,7 @@ $thickLineColor: #cccccc66; // #ffffff99;
 
 #osdContainer {
   height: calc(100vh - $appHeaderHeight - $appFooterHeight);
+  height: calc(100dvh - #{$appHeaderHeight} - #{$appFooterHeight} - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px));
   width: calc(100% - $appSidebarWidth - $contentPreviewPaneWidth);
 
   &.fullWidth {
@@ -332,6 +370,10 @@ $thickLineColor: #cccccc66; // #ffffff99;
 
   .a9s-annotationlayer.a9s-osd-annotationlayer.activeSelection {
     z-index: 12;
+    // Let touch drags reach the drawing layer instead of being consumed as a
+    // browser pan/scroll gesture (required for drawing on touch devices).
+    touch-action: none;
+    pointer-events: all;
   }
 
   .zone {

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -110,6 +110,7 @@ export default {
   text-align: center;
   color: $fontColorDark;
   height: 100vh;
+  height: 100dvh; // track the actual visible height on mobile (collapsing toolbars)
   width: 100%;
   position: relative;
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,9 @@
 
 module.exports = {
-    publicPath: "/myAppPlaceholder"
+    publicPath: "/myAppPlaceholder",
+    devServer: {
+      host: "0.0.0.0",
+      port: 8080,
+      allowedHosts: "all"
+    }
   }


### PR DESCRIPTION
Make layout responsive so the footer stays visible on small screens (100dvh + iOS safe-area insets), fit footer contents on phones, and enable touch drawing without a Shift key. Bind dev server to all interfaces for device testing.
# Testing — Drawing on Small Screens & Responsive Display (#107)

Manual test plan for the responsive layout and touch drawing changes.

## Setup

```bash
npm run serve
```

Open <http://localhost:8080/myAppPlaceholder/>, then load an image / XML so the
canvas and page controls are active.

To test phone sizes without a device: Chrome DevTools → **Cmd+Shift+M**
(Device Toolbar), then pick a device or drag to a custom width.

## A. Responsive layout

Test at **320px, 375px, 412px, 768px, and desktop**:

- [x] Red **footer is visible at the bottom** on every size (the original iPhone mini bug).
- [x] Footer contents (page nav, `zones: N`, mdiv label, progress) **fit without being cut off**.
- [x] No **horizontal scrollbar** on the page.
- [x] Header title **"CartographerApp" isn't clipped**; menu button reachable.
- [x] Rotate to **landscape** — footer still pinned to the bottom.
- [x] Desktop layout is **unchanged** from before.

## B. Touch drawing (core of #107)

In Device Mode (touch emulated) **or** on a real touchscreen:

- [x] Tap the **pen / "draw measures"** tool → drag on the canvas → a rectangle is drawn and a zone is created.
- [x] Draw **several rectangles in a row** without re-selecting the tool.
- [x] Tap the **arrow / "select"** tool → dragging now **pans** the image (no accidental drawing).
- [x] **Pinch-zoom** works in select mode.
- [x] The **"add zone to last measure"** tool also draws by touch.

## C. Desktop regression (mouse)

- [x] Select the draw tool and drag with the mouse → draws (no Shift needed).
- [x] Select tool → mouse drag pans; existing zones are still clickable / selectable.

## D. Edge cases

- [x] Switching pages / loading a new file keeps the correct tool behavior.
- [x] iOS Safari (if reachable): footer clears the home indicator; no content hidden behind the toolbar.

## Testing on a physical phone

The dev server runs on your computer; the phone opens it over the local network.
Both devices must be on the **same Wi-Fi**.

1. **Start the dev server** (it already binds to all interfaces via `vue.config.js`):
   ```bash
   npm run serve
   ```

2. **Find your computer's local IP address:**
   - macOS:
     ```bash
     ipconfig getifaddr en0 || ipconfig getifaddr en1
     ```
   - Linux:
     ```bash
     hostname -I | awk '{print $1}'
     ```
   - Windows (PowerShell):
     ```powershell
     (Get-NetIPAddress -AddressFamily IPv4 | Where-Object {$_.IPAddress -notlike '127.*'}).IPAddress
     ```
   You'll get something like `192.168.1.42` (or `100.64.x.x` on some networks).

3. **On the phone**, open a browser and type the full URL (include `http://`):
   ```
   http://<YOUR-IP>:8080/myAppPlaceholder/
   ```
   Example: `http://192.168.1.42:8080/myAppPlaceholder/`

4. **Run the checks** in sections A and B above (footer visible at the bottom,
   draw with a finger using the pen tool, pan/pinch with the select tool).

### If the page won't load on the phone

Try these in order:

- **Same network:** confirm the phone is on the **exact same Wi-Fi** as the
  computer — not a "guest" SSID, and not on mobile data.
- **Turn off VPN / iCloud Private Relay** on the phone
  (iOS: Settings → Apple Account → iCloud → Private Relay → **Off**; and disable any VPN).
- **Firewall:** allow incoming connections to `node`
  (macOS: System Settings → Network → Firewall).
- **Quick reachability test:** on the phone open `http://<YOUR-IP>:8080/` — if even
  this hangs, the phone genuinely can't reach the computer.
- **Client isolation:** many home/guest routers block device-to-device traffic.
  Work around it by creating a **personal hotspot** on a third device, connect
  **both** the computer and phone to it, then re-run step 2 to get the new IP.

> Note: OAuth/GitHub login won't work over a raw IP (the callback URL is
> registered for a specific origin). Drawing and zone editing still work.
