### PR TITLE
build artifacts at release time

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,7 +1,17 @@
 name: Docker Image CI
 
+# Runs in two situations only (never on every commit):
+#  - push to the `dev` branch  -> builds the `dev` image and deploys it to the
+#    keel staging environment (continuous staging deployment).
+#  - a published GitHub Release -> builds the release image tagged with the
+#    version and `latest` (built once per release).
 on:
   push:
+    branches:
+      - dev
+  release:
+    types: [published]
+  workflow_dispatch:
 
 jobs:
 
@@ -21,8 +31,12 @@ jobs:
       with:
           images: |
             ghcr.io/edirom/cartographer-app
-          flavor: |
-            latest=${{ github.ref == 'refs/heads/main' }}
+          # dev push -> `dev` tag (from branch name); release -> semver version
+          # plus `latest`.
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
          # and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
     - name: build and push Docker image
@@ -36,5 +50,6 @@ jobs:
           build-args: |
               BUILDTYPE=github
     - name: deploy
+      if: github.ref == 'refs/heads/dev'
       run: | 
         curl -X POST https://keel1.edirom.de/v1/webhooks/native -H 'Content-Type: application/json' -d '{"name": "ghcr.io/edirom/cartographer-app", "tag": "dev"}'


### PR DESCRIPTION
 Stop rebuilding the Docker image on every commit. The workflow now runs only:

- **Push to `dev`** → build the `dev` image and deploy to keel staging
- **Published release** → build the image once, tagged with the version and `latest`

Manual runs are still available via `workflow_dispatch`. `main` (and other branches) no longer trigger builds.

Fixes #113