### PR TITLE
Chore/node 24 lts docker - Move to Node 24 LTS and fix docs build under new vite

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,3 +78,6 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "node"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install dependencies
         # The project has a known peer-dependency conflict (vue3-jest vs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- 1) Base build stage ----
-FROM node:20-alpine AS base
+FROM node:24-alpine AS base
 WORKDIR /app
 
 # Install deps first (cache-friendly)

--- a/docs/user/ImportingImages.md
+++ b/docs/user/ImportingImages.md
@@ -25,7 +25,7 @@ Select **“Upload MEI File”** to import an MEI XML file.
 2. Choose one of the following:  
    - **Load Test Data** → imports the sample dataset provided with Cartographer.  
    - **Choose File** → opens a dialog where you can select a file from your computer.  
-   ![Import image window](images/load_mei.png)  
+   ![Import image window](./images/load_mei.png)  
 3. Click **Import** to import the file.  
 4. (Optional) Click **Cancel** to exit without importing.  
 
@@ -51,6 +51,6 @@ When you select **Import IIIF Manifest**, a dialog appears:
 2. Choose one of the following:  
    - **Get Test URI** → use the sample manifest provided with Cartographer.  
    - **Paste Your URI** → enter your own IIIF manifest URI in the input field.  
-      ![Import IIIF Manifest](images/IIIF_Import.png)  
+      ![Import IIIF Manifest](./images/IIIF_Import.png)  
 3. Click **Import** to load the images.  
 4. (Optional) Click **Cancel** to close the dialog without importing.  

--- a/docs/user/UserInterface.md
+++ b/docs/user/UserInterface.md
@@ -9,7 +9,7 @@ The Cartographer App window consists of the following parts:
 3. **Main Working Area** — the central editing space (see number 3 in Image 1).  
 4. **Footer (Bottom Bar)** — displays status information about mdivs, page numbers, and zones (see number 4 in Image 1).  
 
-![Cartographer App Window](images/window.png)  
+![Cartographer App Window](./images/window.png)  
 *Image 1: Layout of the Cartographer App interface*  
 
 ---
@@ -21,7 +21,7 @@ The header contains a **title** (see number 1 in Image 2) and a **dropdown menu 
 Clicking the menu reveals options for uploading or downloading MEI files, and importing IIIF image files.  
 Additionally, the header includes buttons to open the **Page Overview** and toggle the **Measure List**.
 
-![Cartographer App Header](images/header.png)  
+![Cartographer App Header](./images/header.png)  
 *Image 2: Layout of the Cartographer App header*  
 
 ---
@@ -36,7 +36,7 @@ Clicking the dropdown menu in the header opens five options (see Image 3):
 4. **Show Page Overview** — display all imported images and add more images (see number 4 in Image 3).  
 5. **Toggle Measure List** — show or hide a list of all movements and measures in a sidebar (see number 5 in Image 3).  
 
-![Header Menu Bar](images/menubar2.png)  
+![Header Menu Bar](./images/menubar2.png)  
 *Image 3: Header Menu Bar*  
 
 ---
@@ -50,7 +50,7 @@ The footer contains:
 3. **Button to jump to a new page** (see number 3 in Image 9).  
 4. **Zone counter** — shows the total number of zones on the current page (see number 4 in Image 9).  
 
-![Cartographer App Footer](images/footer.png)  
+![Cartographer App Footer](./images/footer.png)  
 *Image 9: Cartographer App Footer*  
 
 ---
@@ -66,5 +66,5 @@ The sidebar contains the following tools:
 5. **Automatic Measure Detection** — run the detector to identify measures automatically (see number 5 in Image 10).  
 6. **Page Navigation** — move between pages of the document (see number 6 in Image 10).  
 
-![Sidebar](images/menu_bar.png)  
+![Sidebar](./images/menu_bar.png)  
 *Image 10: The Cartographer App sidebar*  

--- a/docs/user/actions.md
+++ b/docs/user/actions.md
@@ -30,7 +30,7 @@ Select **"Upload MEI File"** to import an MEI XML file.
    - **"Load Test Data"** → imports the sample dataset provided with Cartographer.  
    - **"Choose File"** → opens a dialog to select a file from your computer.  
 
-   ![Import image window](images/load_mei.png)  
+   ![Import image window](./images/load_mei.png)  
    *Image 1: Import MEI dialog*  
 
 3. Click **"Load"** to import the file.  
@@ -61,7 +61,7 @@ When you select **"Import IIIF Manifest"**, a dialog appears:
    - **"Get Test URI"** → use the sample manifest provided with Cartographer.  
    - **"Paste Your URI"** → enter your own IIIF manifest URI in the input field.  
 
-   ![Import IIIF Manifest](images/IIIF_Import.png)  
+   ![Import IIIF Manifest](./images/IIIF_Import.png)  
    *Image 2: Import IIIF Manifest dialog*  
 
 3. Click **"Import"** to load the images.  
@@ -78,10 +78,10 @@ Click **"Download MEI File"** in the header menu to save the current MEI file to
 Click **"Page Overview"** in the header menu to display a list of all pages with detailed information.  
 This view also contains a button to copy and paste a IIIF manifest (**"Import Images"**).  
 
-![Page Overview](images/imagelist.png)  
+![Page Overview](./images/imagelist.png)  
 *Image 3: Page Overview*  
 
-![Import Images](images/importImages.png)  
+![Import Images](./images/importImages.png)  
 *Image 4: Import Images*  
 
 ---
@@ -89,7 +89,7 @@ This view also contains a button to copy and paste a IIIF manifest (**"Import Im
 ## Toggle Measure List
 Click **"Toggle Measure List"** in the header menu to show or hide the list of musical measures next to the right toolbar.  
 
-![Toggle Measures](images/tougleMeasure.png)  
+![Toggle Measures](./images/tougleMeasure.png)  
 *Image 5: Toggle Measure List*  
 
 ---
@@ -98,12 +98,12 @@ Click **"Toggle Measure List"** in the header menu to show or hide the list of m
 Click **"Select"** (pointer icon) to choose and adjust existing regions. (See number 1 in image 6) 
  
 ---
-![Menu bar actions](images/menu_bar.png) 
+![Menu bar actions](./images/menu_bar.png) 
 *Image 6: Menu bar actions*
 
 
 
-![Menu bar actions](images/footer.png) 
+![Menu bar actions](./images/footer.png) 
 *Image 7: Footer actions*
 
 ## Drawing Measures
@@ -141,7 +141,7 @@ To jump to a specific page, type the page number in the footer’s input box and
 Double click a measure where you want to start a new movement.  
 From the dropdown, select **"new-mdiv"**, then click **"Close"** to confirm.  (See image 8)
 
-![New Movement](images/newMdiv.png)
+![New Movement](./images/newMdiv.png)
 *Image 8: Create New Movement*  
 
 ---
@@ -150,7 +150,7 @@ From the dropdown, select **"new-mdiv"**, then click **"Close"** to confirm.  (S
 Double click the measure you want to edit.  
 Enable **"Explicit @label"**, type the new label, and click **"Close"**.  (See image 9)
 
-![Change Measure Label](images/editMeasure.png) 
+![Change Measure Label](./images/editMeasure.png) 
 *Image 9: Change Measure Label*  
 
 ---
@@ -159,7 +159,7 @@ Enable **"Explicit @label"**, type the new label, and click **"Close"**.  (See i
 Enable **"Multiple Measure Rest"**.  
 Enter the number of measures in the input box, then click **"Close"**.  (See image 10)
 
-![Multiple Measure Rest](images/multipleRest.png)
+![Multiple Measure Rest](./images/multipleRest.png)
 *Image 10: Multiple Measure Rest*
 
 ---
@@ -169,7 +169,7 @@ Click the **"Movement"** button in the lower left corner of the footer.  (See nu
 Edit the movement name in the input box.  (See Image 11)
 When finished, click **"Close"**.  
 
-![Change Movement Label](images/editMovement.png)
+![Change Movement Label](./images/editMovement.png)
 *Image 11: Change Movement Label*  
 
 ## Change Movement
@@ -181,5 +181,5 @@ From this window, choose the movement to which the selected measure should belon
 - If the current movement is **before** the new one, the measure and all following measures will be reassigned.  
 - If the current movement is **after** the new one, the measure and all previous measures will be reassigned.  
 
-![Change Movement Window](images/changeMovement.png)  
+![Change Movement Window](./images/changeMovement.png)  
 *Image 12: Change Movement Window*  

--- a/docs/user/footer.md
+++ b/docs/user/footer.md
@@ -7,5 +7,5 @@ In the Cartographer App, the footer contains:
 3. **Button to jump into a new page** (see number 3 in Image 9)  
 4. **Display of the total number of zones in a page** (see number 4 in Image 9)  
 
-![Cartographer App Footer](images/footer.png)  
+![Cartographer App Footer](./images/footer.png)  
 *Image 9: Cartographer App Footer*

--- a/docs/user/header.md
+++ b/docs/user/header.md
@@ -5,7 +5,7 @@ In the Cartographer App, the header contains a title (see number 1 in Image 2) a
 Clicking the menu reveals buttons for uploading or downloading MEI files, and for loading IIIF image files from a server.  
 Additionally, the header includes buttons to show the **Page Overview** and to toggle the **Measure List**.
 
-![Cartographer App Header](images/header.png)  
+![Cartographer App Header](./images/header.png)  
 *Image 2: Layout of the Cartographer App header*
 
 ---
@@ -14,19 +14,19 @@ Additionally, the header includes buttons to show the **Page Overview** and to t
 
 Clicking the dropdown menu in the header opens five options (see Image 3):
 
-![Header Menu Bar](images/menubar.png)  
+![Header Menu Bar](./images/menubar.png)  
 *Image 3: Header Menu Bar*
 
 ### Upload MEI File
 Opens a file dialog where you can select and upload a local MEI file.  
 
-![Upload MEI File](images/upload_mei.png)  
+![Upload MEI File](./images/upload_mei.png)  
 *Image 4: Upload MEI file*
 
 ### Import IIIF Manifest
 Opens a dialog to enter the URL of a IIIF manifest to load image data from a server.  
 
-![Import IIIF Manifest](images/importIIIf.png)  
+![Import IIIF Manifest](./images/importIIIf.png)  
 *Image 5: Import IIIF manifest*
 
 ### Download MEI File
@@ -36,14 +36,14 @@ Saves the current MEI file to your local machine.
 Displays a list of all pages with detailed information from an imported file (see figure 6).  
 It also contains a button to copy and paste a IIIF manifest (*Import Images button*, figure 7).
 
-![Page Overview](images/imagelist.png)  
+![Page Overview](./images/imagelist.png)  
 *Image 6: Display list of images*
 
-![Import Images](images/importImages.png)  
+![Import Images](./images/importImages.png)  
 *Image 7: Import Images*
 
 ### Toggle Measure List
 Shows or hides the list of musical measures of the document next to the right toolbar.
 
-![Toggle Measures](images/tougleMeasure.png)  
+![Toggle Measures](./images/tougleMeasure.png)  
 *Image 8: Toggle Measures*


### PR DESCRIPTION
Two related changes that keep the Docker build green:

**Node 24 LTS everywhere**
- Dockerfile: `node:20-alpine` → `node:24-alpine`
- CI workflows: `node-version: 20` → `24`
- `dependabot.yml`: ignore Current-line Node majors for the Docker image

**Docs build fix**
- Prefix relative image paths in `docs/**/*.md` with `./` (27 references
  across 5 files)