### PR TITLE
Add GitHub Device Flow login for native Tauri builds (#165)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@fortawesome/vue-fontawesome": "^3.3.3",
         "@octokit/rest": "^22.0.1",
         "@recogito/annotorious-openseadragon": "^2.7.6",
+        "@tauri-apps/api": "^2.11.1",
         "core-js": "^3.49.0",
         "openseadragon": "^3.0.0",
         "spectre.css": "^0.5.9",
@@ -5126,6 +5127,16 @@
       "resolved": "https://registry.npmjs.org/@soda/get-current-script/-/get-current-script-1.0.2.tgz",
       "integrity": "sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==",
       "dev": true
+    },
+    "node_modules/@tauri-apps/api": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
+      "integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
+      "license": "Apache-2.0 OR MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
+      }
     },
     "node_modules/@tauri-apps/cli": {
       "version": "2.11.4",
@@ -24903,21 +24914,6 @@
         "quickselect": "^2.0.0"
       }
     },
-    "node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-autosize-textarea": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-7.1.0.tgz",
@@ -24930,22 +24926,6 @@
       "peerDependencies": {
         "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
         "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
       }
     },
     "node_modules/react-draggable": {
@@ -25755,17 +25735,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "node_modules/schema-utils": {
@@ -27652,21 +27621,6 @@
       "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/uc.micro": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@fortawesome/vue-fontawesome": "^3.3.3",
     "@octokit/rest": "^22.0.1",
     "@recogito/annotorious-openseadragon": "^2.7.6",
+    "@tauri-apps/api": "^2.11.1",
     "core-js": "^3.49.0",
     "openseadragon": "^3.0.0",
     "spectre.css": "^0.5.9",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -57,6 +57,7 @@ checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 name = "app"
 version = "0.1.0"
 dependencies = [
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -346,6 +347,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +447,15 @@ name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -1047,8 +1068,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1070,8 +1093,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1319,6 +1345,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1708,6 +1750,12 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2372,6 +2420,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,6 +2495,32 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2478,6 +2608,44 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -2511,6 +2679,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2535,10 +2717,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safemem"
@@ -2745,6 +2968,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,7 +3049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.5",
  "digest",
 ]
 
@@ -2941,6 +3176,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3099,7 +3340,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3401,6 +3642,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3678,6 +3929,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3866,6 +4123,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3919,6 +4186,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4162,6 +4438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4511,6 +4796,12 @@ dependencies = [
  "syn 2.0.118",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-build = { version = "2", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "2", features = [] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 [features]
 # by default Tauri runs in production mode
@@ -32,3 +33,6 @@ default = [ "custom-protocol" ]
 # this feature is used for production builds where `devPath` points to the filesystem
 # DO NOT remove this
 custom-protocol = [ "tauri/custom-protocol" ]
+
+
+

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,9 +4,35 @@
 // the native wrapper loads, so the Tauri setup lives here in `run()` and is
 // exposed through the `mobile_entry_point`. The desktop binary in `main.rs`
 // simply calls this same function.
+
+#[tauri::command]
+async fn gh_device_code(client_id: String) -> Result<serde_json::Value, String> {
+    reqwest::Client::new()
+        .post("https://github.com/login/device/code")
+        .header("Accept", "application/json")
+        .form(&[("client_id", client_id.as_str()), ("scope", "repo user:email")])
+        .send().await.map_err(|e| e.to_string())?
+        .json().await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn gh_poll_token(client_id: String, device_code: String) -> Result<serde_json::Value, String> {
+    reqwest::Client::new()
+        .post("https://github.com/login/oauth/access_token")
+        .header("Accept", "application/json")
+        .form(&[
+            ("client_id", client_id.as_str()),
+            ("device_code", device_code.as_str()),
+            ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+        ])
+        .send().await.map_err(|e| e.to_string())?
+        .json().await.map_err(|e| e.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![gh_device_code, gh_poll_token])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/components/MainMenu.vue
+++ b/src/components/MainMenu.vue
@@ -85,12 +85,29 @@
         </li>
       </template>
     </ul>
+
+    <!-- GitHub Device Flow prompt (native/Tauri builds). Lives outside the
+         dropdown list so it survives the menu closing while the user enters
+         the code at github.com/login/device. Cleared automatically by the
+         auth/loginDevice action on success, error, or timeout. -->
+    <div v-if="devicePrompt" class="device-login-card">
+      <p class="device-login-title">Sign in with GitHub</p>
+      <p>Visit
+        <a :href="devicePrompt.uri" target="_blank" rel="noopener">{{ devicePrompt.uri }}</a>
+        and enter this code:
+      </p>
+      <div class="device-code-row">
+        <code class="device-code">{{ devicePrompt.userCode }}</code>
+        <button class="btn btn-sm" @click="copyDeviceCode" title="Copy code">
+          <font-awesome-icon icon="fa-solid fa-copy"/>
+        </button>
+      </div>
+      <p class="device-login-hint">Waiting for authorization… Only enter this code if you just requested it here.</p>
+    </div>
   </div>
 </template>
 
 <script>
-import { mapGetters, mapActions } from 'vuex'
-
 export default {
   name: 'MainMenu',
   props: {
@@ -129,6 +146,9 @@ export default {
         (this.selectedBranch && this.selectedBranch.name)
       return branch ? 'GitHub · ' + branch : 'GitHub'
     },
+    devicePrompt: function () {
+      return this.$store.state.auth.devicePrompt
+    },
   },
   methods: {
     importXML: function () {
@@ -144,7 +164,18 @@ export default {
       this.$store.dispatch('toggleLoadGitModal')
     },
     loginToGithub: function () {
-      this.$store.dispatch('auth/login')
+      if (window.__TAURI_INTERNALS__) {
+        this.$store.dispatch('auth/loginDevice').catch(err => {
+          alert('GitHub login failed: ' + err.message)
+        })
+      } else {
+        this.$store.dispatch('auth/login')
+      }
+    },
+    copyDeviceCode: function () {
+      if (this.devicePrompt) {
+        navigator.clipboard.writeText(this.devicePrompt.userCode)
+      }
     },
     commitToGithub: function () {
       this.$store.dispatch('toggleCommitModal')
@@ -224,6 +255,46 @@ button {
     position: relative;
     top: -1px;
     padding-right: 5px;
+  }
+}
+
+.device-login-card {
+  position: fixed;
+  top: 4rem;
+  right: 1rem;
+  z-index: 400;
+  width: 280px;
+  padding: .8rem;
+  background: #fff;
+  border: 1px solid $fontColorDark;
+  border-radius: .3rem;
+  box-shadow: 0 .2rem .5rem rgba(0,0,0,.2);
+  color: $fontColorDark;
+  text-align: left;
+
+  .device-login-title {
+    font-weight: 600;
+    margin-bottom: .4rem;
+  }
+
+  .device-code-row {
+    display: flex;
+    align-items: center;
+    gap: .4rem;
+    margin: .4rem 0;
+  }
+
+  .device-code {
+    font-size: 1.1rem;
+    letter-spacing: .15em;
+    padding: .2rem .5rem;
+    background: rgba(0, 0, 0, .05);
+  }
+
+  .device-login-hint {
+    font-size: .65rem;
+    opacity: .75;
+    margin-top: .4rem;
   }
 }
 </style>

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -71,6 +71,7 @@ export default {
     branches: [],             // branches of the selected repository
     selectedBranch: null,     // { name } of the selected branch
     loadingBranches: false,
+    devicePrompt: null,       // { userCode, uri } while device-flow login is pending
   }),
 
   mutations: {
@@ -133,6 +134,9 @@ export default {
       state.repoContents = []
       state.selectedFile = null
     },
+    SET_DEVICE_PROMPT (state, prompt) {
+      state.devicePrompt = prompt
+    },
   },
 
   actions: {
@@ -150,7 +154,33 @@ export default {
       })
       window.location.href = `https://github.com/login/oauth/authorize?${params}`
     },
+    /** GitHub Device Flow login for the native (Tauri) builds. */
+    async loginDevice ({ commit, dispatch }) {
+      const { invoke } = await import('@tauri-apps/api/core')
+      const clientId = process.env.GH_APP_CLIENT_ID
+      const dc = await invoke('gh_device_code', { clientId })
 
+      commit('SET_DEVICE_PROMPT', { userCode: dc.user_code, uri: dc.verification_uri })
+
+      let interval = (dc.interval || 5) * 1000
+      const deadline = Date.now() + dc.expires_in * 1000
+      try {
+        while (Date.now() < deadline) {
+          await new Promise(resolve => setTimeout(resolve, interval))
+          const res = await invoke('gh_poll_token', { clientId, deviceCode: dc.device_code })
+          if (res.access_token) {
+            commit('SET_TOKEN', res.access_token)
+            return dispatch('fetchUser')
+          }
+          if (res.error === 'authorization_pending') continue
+          if (res.error === 'slow_down') { interval += 5000; continue }
+          throw new Error(res.error_description || res.error)
+        }
+        throw new Error('Login timed out — please try again')
+      } finally {
+        commit('SET_DEVICE_PROMPT', null)
+      }
+    },
     /** Exchange the OAuth authorization code for an access token. */
     async authenticate ({ commit, dispatch }, { code }) {
       // GitHub requires the client_secret at the token endpoint and that
@@ -415,6 +445,30 @@ export default {
       commit('SET_REPO_CONTENTS', [])
       commit('CLEAR_SELECTED_REPO')
     },
+    async loginDevice ({ commit, dispatch }) {
+  const { invoke } = await import('@tauri-apps/api/core')
+  const clientId = process.env.GH_APP_CLIENT_ID
+  const dc = await invoke('gh_device_code', { clientId })
+
+  // Show dc.user_code + dc.verification_uri in the UI (copy button recommended)
+  commit('SET_DEVICE_PROMPT', { userCode: dc.user_code, uri: dc.verification_uri })
+
+  let interval = (dc.interval || 5) * 1000
+  const deadline = Date.now() + dc.expires_in * 1000
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, interval))
+    const res = await invoke('gh_poll_token', { clientId, deviceCode: dc.device_code })
+    if (res.access_token) {
+      commit('SET_DEVICE_PROMPT', null)
+      commit('SET_TOKEN', res.access_token)   // reuses existing mutation
+      return dispatch('fetchUser')            // everything downstream unchanged
+    }
+    if (res.error === 'authorization_pending') continue
+    if (res.error === 'slow_down') { interval += 5000; continue }
+    throw new Error(res.error_description || res.error)
+  }
+  throw new Error('Device flow timed out — please try again')
+  }
   },
 
   getters: {


### PR DESCRIPTION
## Summary

GitHub login previously dead ended in packaged Tauri apps:  the token exchange endpoint (`/auth`) only exists in the dev proxy and the nginx container. This PR adds a native compatible login path using the **GitHub Device Flow**, which is designed for clients that cannot hold a secret: the app displays a one-time code, the user confirms it at github.com/login/device, and the app polls for the access token.

- **No client secret involved** — nothing secret ships in the APK or desktop binary, and no hosted exchange endpoint is required, keeping native builds fully self-contained (matching the app's offline/local-use goal).
- **Web flow untouched** — the browser and Docker/nginx deployments keep the existing redirect + proxy exchange; the device flow only activates when running under Tauri (`window.__TAURI_INTERNALS__`).
- Everything downstream of login (user info, repo browsing, file load/commit via Octokit) is unchanged and shared between both flows.

## Changes

- `src-tauri/src/lib.rs`: two Tauri commands (`gh_device_code`, `gh_poll_token`) that call GitHub's device-flow endpoints from the Rust side, since GitHub's OAuth endpoints have no CORS support.
- `src-tauri/Cargo.toml` / `Cargo.lock`: add `reqwest` with `rustls-tls` (pure-Rust TLS) instead of native-tls, so the crate cross-compiles for Android without an OpenSSL sysroot.
- `src/store/modules/auth.js`: new `loginDevice` action (device code request, polling with `authorization_pending` / `slow_down` handling, timeout) plus `devicePrompt` state; reuses the existing `SET_TOKEN` / `fetchUser` path.
- `src/components/MainMenu.vue`: login trigger branches on Tauri; new prompt card showing the verification URL and user code (with copy button) while authorization is pending.
- `package.json` / `package-lock.json`: add `@tauri-apps/api`.

## Setup required

The GitHub OAuth App needs **"Enable Device Flow"** checked in its settings. Native builds only need `GH_APP_CLIENT_ID` in `.env.local` at build time  the callback URL is not used by the device flow.

## Testing

- [x] Web flow unchanged (`npm run serve`): redirect login works as before
- [x] macOS dev (`tauri:dev`): device-flow login end to end, repo load
- [x] macOS packaged (`tauri:build`): device-flow login end to end
- [x] Android APK: builds (rustls), signs, and verifies; bundle contains no
      client secret (verified via grep on the packaged assets)
- [x] Android runtime: not yet tested on hardware/emulator. Same code path
      as macOS, but webview link-opening and clipboard behavior should be
      verified on a device (follow-up: consider opener/clipboard plugins)

## Security notes

- The client secret remains absent from all bundles by design; suggest a CI guard (`grep -r GH_APP_CLIENT_SECRET dist/` after build) as a follow-up.
- The access token is session-only